### PR TITLE
Formvalues sectionprefix update (#3210)

### DIFF
--- a/src/__tests__/formValues.spec.js
+++ b/src/__tests__/formValues.spec.js
@@ -5,6 +5,7 @@ import { Provider } from 'react-redux'
 import { combineReducers as plainCombineReducers, createStore } from 'redux'
 import { combineReducers as immutableCombineReducers } from 'redux-immutablejs'
 import TestUtils from 'react-dom/test-utils'
+import ReactDOM from 'react-dom'
 import createReducer from '../createReducer'
 import createReduxForm from '../createReduxForm'
 import formValues from '../formValues'
@@ -35,7 +36,15 @@ const describeValues = (
     form: 'test',
     initialValues: fromJS({
       cat: 'rat',
-      sub: { dog: 'cat' }
+      sub: { dog: 'cat' },
+      arr: [
+        {
+          rat: 'cat'
+        },
+        {
+          rat: 'dog'
+        },
+      ]
     })
   })(props => <div {...props} />)
 
@@ -91,6 +100,37 @@ const describeValues = (
     it('should work in FormSection', () => {
       const props = testProps(true, 'dog')
       expect(props.dog).toEqual('cat')
+    })
+
+    it('should update props when FormSection name changes', () => {
+      const node = document.createElement('div');
+      const Spy = createSpy(() => <div />).andCallThrough()
+      const Decorated = formValues('rat')(Spy)
+
+      const Component = ({ name }) => (
+        <Provider store={store}>
+          <Form>
+            <FormSection name={name}>
+              <Decorated />
+            </FormSection>
+          </Form>
+        </Provider>
+      )
+
+      ReactDOM.render(
+        <Component name='arr[0]' />,
+        node
+      );
+
+      ReactDOM.render(
+        <Component name='arr[1]' />,
+        node
+      );
+
+      expect(Spy.calls.length).toEqual(2)
+
+      expect(Spy.calls[0].arguments[0].rat).toEqual('cat')
+      expect(Spy.calls[1].arguments[0].rat).toEqual('dog')
     })
   })
 }

--- a/src/createFormValues.js
+++ b/src/createFormValues.js
@@ -45,8 +45,10 @@ const createValues = ({ getIn }: Structure<*, *>): FormValuesInterface => (
             'formValues() must be used inside a React tree decorated with reduxForm()'
           )
         }
-        const formValuesSelector = _ => {
-          // Yes, we're only using connect() for listening to updates
+        const formValuesSelector = (_, { sectionPrefix }) => {
+          // Yes, we're only using connect() for listening to updates.
+          // The second argument needs to be there so that connect calls
+          // the selector when props change
           const { getValues } = this.context._reduxForm
           const props = {}
           const values = getValues()
@@ -59,10 +61,14 @@ const createValues = ({ getIn }: Structure<*, *>): FormValuesInterface => (
         this.Component = connect(
           formValuesSelector,
           () => ({}) // ignore dispatch
-        )(Component)
+        )(({ sectionPrefix, ...otherProps }) => (<Component {...otherProps} />))
       }
       render() {
-        return <this.Component {...this.props} />
+        return <this.Component
+          // so that the connected component updates props when sectionPrefix has changed
+          sectionPrefix={this.context._reduxForm.sectionPrefix}
+          {...this.props}
+        />
       }
     }
     FormValues.contextTypes = {


### PR DESCRIPTION
* Force update of formValues props on context._reduxForm.sectionPrefix update

* Added props to the formValues selector so that it is called when sectionPrefix has changed

* Added test for formValues update inside FormSection